### PR TITLE
Update to python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.o
 *.a
 *.inc
+*.tmp
+tags

--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ Includes:
 * ELF object file output
 * Linker
 * `ar` clone
+
+Dependencies:
+
+* make
+* nasm
+* ctags

--- a/meta/enc.py
+++ b/meta/enc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 # Generates code for encoding assembly instructions (and potentially decoding
 # in the future for a disassembler). The format that is parsed matches the
@@ -215,7 +215,7 @@ def arg_conditions(args):
                 + ' && {0}.u.reg.u.class == {1}'
                 + ' && {0}.u.reg.width == {2})').format(arg_str, reg_class, width))
         else:
-            print "Unknown arg type: '%s'" % arg
+            print("Unknown arg type: '%s'" % arg)
             assert False
 
     return ' && '.join(conditions)
@@ -235,7 +235,7 @@ def to_c_val(x):
 
 if __name__ == '__main__':
     if len(sys.argv) not in (2, 3):
-        print "Usage: %s <enc definition> [output file]" % sys.argv[0]
+        print("Usage: %s <enc definition> [output file]" % sys.argv[0])
         sys.exit(1)
 
     # @PORT

--- a/meta/peg.py
+++ b/meta/peg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 # Quick and dirty PEG generator.
 
@@ -68,7 +68,7 @@ class Reader(object):
         return self.tokens[self.position + offset]
 
     def read_token(self):
-        #print self.at(0)
+        #print(self.at(0))
         self.position += 1
         return self.at(-1)
 
@@ -76,7 +76,7 @@ class Reader(object):
         name = self.read_token()
         equals = self.read_token()
 
-        assert all(ident_char(c) for c in name)
+        assert all([ident_char(c) for c in name])
         assert equals == '='
 
         parser = self.read_parser()
@@ -150,8 +150,8 @@ static Token _unexpected_token;
             # We prefix with 'p' because otherwise we  generate reserved names
             # like '__foo' in some cases.
             name = 'p' + \
-                    ''.join('_' if c in "[], \"'" else c for c in `parser`) + \
-                    `len(self.definitions)`
+                    ''.join('_' if c in "[], \"'" else c for c in repr(parser)) + \
+                    repr(len(self.definitions))
         if isinstance(parser, str):
             if parser.startswith('TOK_'):
                 return self.emit_function(
@@ -208,12 +208,12 @@ if (token->t == TOK_SYMBOL && streq(token->u.symbol, "%s")) {
             result_type = args[0]
             arity = int(args[1])
             signature = 'static %s *%s(Parser *parser%s)' % \
-                (result_type, name, ''.join(', void *arg' + `i` for i in xrange(arity)))
-            field_map = [args[i:i+2] for i in xrange(2, len(args), 2)]
+                (result_type, name, ''.join([', void *arg' + str(i) for i in range(arity)]))
+            field_map = [args[i:i+2] for i in range(2, len(args), 2)]
             prologue = '\n%s *result = pool_alloc(parser->pool, sizeof *result);\n' % result_type
-            prologue += ' '.join('(void)arg%d;' % i for i in xrange(arity)) + '\n'
-            field_assigners = ''.join(
-                field_assigner(field_name, assigner) for field_name, assigner in field_map)
+            prologue += ' '.join(['(void)arg%d;' % i for i in range(arity)]) + '\n'
+            field_assigners = ''.join([
+                field_assigner(field_name, assigner) for field_name, assigner in field_map])
             epilogue = 'return result;'
 
             return self.emit_function(
@@ -236,7 +236,7 @@ u32 start; (void)start;
             else:
                 ret_body = lambda i: "\treturn result;"
 
-            main = ''.join(
+            main = ''.join([
 """
 start = parser->position;
 result = %s(parser);
@@ -244,27 +244,27 @@ if (result.success) {
 %s
 }
 parser->position = start;
-""" % (self.generate_parser(arg), ret_body(i)) for i, arg in enumerate(args))
+""" % (self.generate_parser(arg), ret_body(i)) for i, arg in enumerate(args)])
 
             epilogue = "return failure;"
 
             return self.emit_function(prologue + main + epilogue, name)
         elif operator == 'seq':
-            args = map(self.generate_parser, args)
+            args = list(map(self.generate_parser, args))
             prologue = "\nu32 start = parser->position;"
-            main = ''.join(
+            main = ''.join([
 """
 ParserResult _{0}_result{1} = {0}(parser);
 if (!_{0}_result{1}.success)
 \treturn revert(parser, start);
-""".format(p, i) for i, p in enumerate(args[1:]))
-            result_args = ''.join(', _%s_result%d.result' % (p, i) for i, p in
-                    enumerate(args[1:]))
+""".format(p, i) for i, p in enumerate(args[1:])])
+            result_args = ''.join([', _%s_result%d.result' % (p, i) for i, p in
+                    enumerate(args[1:])])
             epilogue = "\nreturn success(%s(parser%s));" % (args[0], result_args)
 
             return self.emit_function(prologue + main + epilogue, name)
         elif operator == 'fold':
-            args = map(self.generate_parser, args)
+            args = list(map(self.generate_parser, args))
             return self.emit_function(
 """
 ParserResult initial = %s(parser);
@@ -313,7 +313,7 @@ for (;;) {
             return self.emit_function(
 "\nreturn success(%s(parser).result);" % self.generate_parser(args[0]), name)
         else:
-            print "Unknown operator: " + operator
+            print("Unknown operator: " + operator)
             assert not "Unreachable"
 
 def field_assigner(field_name, assigner_expr):
@@ -323,7 +323,7 @@ def field_assigner(field_name, assigner_expr):
 
 if __name__ == '__main__':
     if len(sys.argv) not in (2, 3):
-        print "Usage: %s <peg definition> [output file]" % sys.argv[0]
+        print("Usage: %s <peg definition> [output file]" % sys.argv[0])
         sys.exit(1)
 
     # @PORT

--- a/meta/peg.py
+++ b/meta/peg.py
@@ -76,7 +76,7 @@ class Reader(object):
         name = self.read_token()
         equals = self.read_token()
 
-        assert all([ident_char(c) for c in name])
+        assert all(ident_char(c) for c in name)
         assert equals == '='
 
         parser = self.read_parser()
@@ -208,12 +208,12 @@ if (token->t == TOK_SYMBOL && streq(token->u.symbol, "%s")) {
             result_type = args[0]
             arity = int(args[1])
             signature = 'static %s *%s(Parser *parser%s)' % \
-                (result_type, name, ''.join([', void *arg' + str(i) for i in range(arity)]))
+                (result_type, name, ''.join(', void *arg' + str(i) for i in range(arity)))
             field_map = [args[i:i+2] for i in range(2, len(args), 2)]
             prologue = '\n%s *result = pool_alloc(parser->pool, sizeof *result);\n' % result_type
-            prologue += ' '.join(['(void)arg%d;' % i for i in range(arity)]) + '\n'
-            field_assigners = ''.join([
-                field_assigner(field_name, assigner) for field_name, assigner in field_map])
+            prologue += ' '.join('(void)arg%d;' % i for i in range(arity)) + '\n'
+            field_assigners = ''.join(
+                field_assigner(field_name, assigner) for field_name, assigner in field_map)
             epilogue = 'return result;'
 
             return self.emit_function(
@@ -236,7 +236,7 @@ u32 start; (void)start;
             else:
                 ret_body = lambda i: "\treturn result;"
 
-            main = ''.join([
+            main = ''.join(
 """
 start = parser->position;
 result = %s(parser);
@@ -244,7 +244,7 @@ if (result.success) {
 %s
 }
 parser->position = start;
-""" % (self.generate_parser(arg), ret_body(i)) for i, arg in enumerate(args)])
+""" % (self.generate_parser(arg), ret_body(i)) for i, arg in enumerate(args))
 
             epilogue = "return failure;"
 
@@ -252,14 +252,14 @@ parser->position = start;
         elif operator == 'seq':
             args = list(map(self.generate_parser, args))
             prologue = "\nu32 start = parser->position;"
-            main = ''.join([
+            main = ''.join(
 """
 ParserResult _{0}_result{1} = {0}(parser);
 if (!_{0}_result{1}.success)
 \treturn revert(parser, start);
-""".format(p, i) for i, p in enumerate(args[1:])])
-            result_args = ''.join([', _%s_result%d.result' % (p, i) for i, p in
-                    enumerate(args[1:])])
+""".format(p, i) for i, p in enumerate(args[1:]))
+            result_args = ''.join(', _%s_result%d.result' % (p, i) for i, p in
+                    enumerate(args[1:]))
             epilogue = "\nreturn success(%s(parser%s));" % (args[0], result_args)
 
             return self.emit_function(prologue + main + epilogue, name)

--- a/run_tests.py
+++ b/run_tests.py
@@ -102,7 +102,6 @@ def start_compiling(test_dir):
     test_filenames = []
     extra_flags = []
     for filename in sub_files:
-        print(test_dir, filename)
         with open(os.path.join(test_dir, filename), 'rb') as f:
             contents = f.read()
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -220,7 +220,7 @@ def indent_bytes(bs):
     return indent(bs.decode())
 
 def indent(string):
-    return '\n'.join(["    " + line for line in string.split('\n')])
+    return '\n'.join("    " + line for line in string.split('\n'))
 
 # @TODO: check if we're on a platform that doesn't support ANSI colors
 green = '\033[92m'

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import fnmatch
 import multiprocessing
@@ -24,11 +24,11 @@ def main():
         else:
             tests.append(arg)
     if not print_details and be_positive:
-        print "Cannot specify '-s' and '-p'"
+        print("Cannot specify '-s' and '-p'")
         return
     if create_testcase:
         if len(tests) == 0:
-            print "Must specify a list of tests if passing '-c'"
+            print("Must specify a list of tests if passing '-c'")
             return
         map(create_test_files, tests)
         return
@@ -41,7 +41,7 @@ def main():
     num_tests = len(tests)
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    print "Running %d tests:" % num_tests
+    print("Running %d tests:" % num_tests)
 
     # Try to keep n compiler processes running at once, where n = the number of
     # cpu cores on this machine.
@@ -68,19 +68,19 @@ def main():
             sys.stdout.flush()
             results.append(test_result)
 
-    print "\n"
+    print("\n")
 
     passes = sum(1 for result in results if result.passed())
-    print "%d / %d tests passed" % (passes, num_tests)
+    print("%d / %d tests passed" % (passes, num_tests))
 
     if print_details:
         results.sort(key=lambda r: r.name)
         for result in results:
             if be_positive:
                 if result.passed():
-                    print "test '%s' passed" % result.name
+                    print("test '%s' passed" % result.name)
             elif not result.passed():
-                print "\ntest '%s' failed:\n%s" % (result.name, result.error)
+                print("\ntest '%s' failed:\n%s" % (result.name, result.error))
 
 class Testcase(object):
     __slots__ = ['name', 'binary', 'cc_proc',
@@ -93,16 +93,17 @@ def start_compiling(test_dir):
 
     sub_files = os.listdir(test_dir)
 
-    testcase.expected_compile_stdout = ''
-    testcase.expected_compile_stderr = ''
-    testcase.expected_run_stdout = ''
-    testcase.expected_run_stderr = ''
-    testcase.run_stdin = ''
+    testcase.expected_compile_stdout = b''
+    testcase.expected_compile_stderr = b''
+    testcase.expected_run_stdout = b''
+    testcase.expected_run_stderr = b''
+    testcase.run_stdin = b''
 
     test_filenames = []
     extra_flags = []
     for filename in sub_files:
-        with open(os.path.join(test_dir, filename), 'r') as f:
+        print(test_dir, filename)
+        with open(os.path.join(test_dir, filename), 'rb') as f:
             contents = f.read()
 
         if filename == 'compile_stdout':
@@ -117,7 +118,7 @@ def start_compiling(test_dir):
             testcase.run_stdin = contents
         elif filename.endswith('.c'):
             test_filenames.append(filename)
-            first_line = contents[:contents.index('\n')]
+            first_line = contents[:contents.index(b'\n')].decode()
             flags_str = '// FLAGS:'
             if first_line.startswith(flags_str):
                 extra_flags = first_line[len(flags_str):].strip().split(' ')
@@ -179,17 +180,17 @@ def run_testcase(testcase):
                 test_result.error = "compilation succeeded when expected to fail"
             else:
                 test_result.error = "expected compile stderr:\n%s\ngot:\n%s" \
-                    % (indent(testcase.expected_compile_stderr), indent(compile_stderr))
+                    % (indent_bytes(testcase.expected_compile_stderr), indent_bytes(compile_stderr))
             return test_result
         else:
             return test_result
     if compile_stdout != testcase.expected_compile_stdout:
         test_result.error = "expected compile stdout:\n%s\ngot:\n%s" \
-                % (indent(testcase.expected_compile_stdout), indent(compile_stdout))
+                % (indent_bytes(testcase.expected_compile_stdout), indent_bytes(compile_stdout))
 
     if not compiled_successfully:
         test_result.error = "compilation failed with stderr:\n" \
-            + indent(compile_stderr)
+            + indent_bytes(compile_stderr)
         return test_result
 
     binary_path = os.path.abspath(testcase.binary)
@@ -215,8 +216,11 @@ def run_testcase(testcase):
 
     return test_result
 
+def indent_bytes(bs):
+    return indent(bs.decode())
+
 def indent(string):
-    return '\n'.join("    " + line for line in string.split('\n'))
+    return '\n'.join(["    " + line for line in string.split('\n')])
 
 # @TODO: check if we're on a platform that doesn't support ANSI colors
 green = '\033[92m'


### PR DESCRIPTION
As Python2 is no longer maintained, this change is an attempt to move naive to use Python3.

Note: Tests currently fail on my machine, but I assume this is due to my use of WSL2 or a misconfiguration

An example failure:
```
test 'tests/ncc/void' failed:
compilation failed with stderr:
    Relocations for that section are not supported (found rela section .rela.data.rel.local)
    Relocations for that section are not supported (found rela section .rela.data.rel.local)
    Relocations for that section are not supported (found rela section .rela.data.rel.local)
    Relocations for that section are not supported (found rela section .rela.rodata)
    Unsupported relocation type: 4
    ncc: src/elf.c:1194: link_elf_executable: Assertion `false' failed.
```